### PR TITLE
Test for join over data tables

### DIFF
--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -211,6 +211,40 @@ test_that("joining data tables yields a data table (#470)", {
   expect_is(out, "data.table")
 })
 
+test_that("joining data tables does not modify them (#659)", {
+  a <- data.table::data.table(x = c(1, 1, 2, 3), y = 4:1)
+  b <- data.table::data.table(x = c(1, 2, 2, 4), z = 1:4)
+
+  for (ak in names(a)) {
+    for (bk in names(b)) {
+      label <- sprintf("keys: %s, %s", ak, bk)
+      data.table::setkeyv(a, ak)
+      data.table::setkeyv(b, bk)
+      ac <- data.table::copy(a)
+      bc <- data.table::copy(b)
+
+      out <- left_join(a, b, "x")
+      expect_equal(a, ac, label = label)
+      expect_equal(b, bc, label = label)
+      out <- semi_join(a, b, "x")
+      expect_equal(a, ac, label = label)
+      expect_equal(b, bc, label = label)
+      out <- right_join(a, b, "x")
+      expect_equal(a, ac, label = label)
+      expect_equal(b, bc, label = label)
+      out <- full_join(a, b, "x")
+      expect_equal(a, ac, label = label)
+      expect_equal(b, bc, label = label)
+      out <- inner_join(a, b, "x")
+      expect_equal(a, ac, label = label)
+      expect_equal(b, bc, label = label)
+      out <- anti_join(a, b, "x")
+      expect_equal(a, ac, label = label)
+      expect_equal(b, bc, label = label)
+    }
+  }
+})
+
 test_that("inner_join is symmetric (even when joining on character & factor)", {
   foo <- data_frame(id = factor(c("a", "b")), var1 = "foo")
   bar <- data_frame(id = c("a", "b"), var2 = "bar")


### PR DESCRIPTION
Tests that join operations don't change the source data tables. Fails if data.table::copy is omitted in `join_dt()`.

Related to #659.
