### PR TITLE
Rewrite grouped summary processing code

### DIFF
--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -59,7 +59,7 @@ namespace dplyr {
     }
 
     template <typename Container>
-    DataFrame subset_impl(const Container& index, const CharacterVector& classes, traits::false_type) const {
+    DataFrame subset_impl(const Container& index, const CharacterVector& classes, Rcpp::traits::false_type) const {
       List out(nvisitors);
       for (int k=0; k<nvisitors; k++) {
         out[k] = get(k)->subset(index);
@@ -70,7 +70,7 @@ namespace dplyr {
     }
 
     template <typename Container>
-    DataFrame subset_impl(const Container& index, const CharacterVector& classes, traits::true_type) const {
+    DataFrame subset_impl(const Container& index, const CharacterVector& classes, Rcpp::traits::true_type) const {
       int n = index.size();
       int n_out = std::count(index.begin(), index.end(), TRUE);
       IntegerVector idx = no_init(n_out);
@@ -79,7 +79,7 @@ namespace dplyr {
           idx[k++] = i;
         }
       }
-      return subset_impl(idx, classes, traits::false_type());
+      return subset_impl(idx, classes, Rcpp::traits::false_type());
     }
 
     template <typename Container>
@@ -87,7 +87,7 @@ namespace dplyr {
       return
         subset_impl(
           index, classes,
-          typename traits::same_type<Container, LogicalVector>::type()
+          typename Rcpp::traits::same_type<Container, LogicalVector>::type()
         );
     }
 

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -22,7 +22,7 @@ namespace dplyr {
   template <int RTYPE, typename Data, typename Subsets>
   class GathererImpl : public Gatherer {
   public:
-    typedef typename traits::storage_type<RTYPE>::type STORAGE;
+    typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
     typedef GroupedCallProxy<Data,Subsets> Proxy;
 
     GathererImpl(RObject& first, SlicingIndex& indices, Proxy& proxy_, const Data& gdf_, int first_non_na_) :

--- a/inst/include/dplyr/Replicator.h
+++ b/inst/include/dplyr/Replicator.h
@@ -14,7 +14,7 @@ namespace dplyr {
   template <int RTYPE, typename Data>
   class ReplicatorImpl : public Replicator {
   public:
-    typedef typename traits::storage_type<RTYPE>::type STORAGE;
+    typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
     ReplicatorImpl(SEXP v, int n_, int ngroups_) :
       data(no_init(n_*ngroups_)), source(v), n(n_), ngroups(ngroups_) {}

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -71,7 +71,7 @@ namespace dplyr {
 
       for (int i = 0; i < ngroups; ++i, ++git) {
         first_result = obj->process_chunk(*git);
-        if (!processor->handled(i, first_result)) {
+        if (!processor->try_handle(i, first_result)) {
           LOG_VERBOSE << "not handled group " << i;
 
           if (processor->can_promote(first_result)) {

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -98,6 +98,8 @@ namespace dplyr {
             processor.reset(
               processor->promote(i, first_result)
             );
+          } else {
+            stop("can't promote group %d", i);
           }
         }
       }

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -77,7 +77,7 @@ namespace dplyr {
       void process_rest() {
         for (int i = 1; i < ngroups; ++i) {
           const RObject& chunk = fetch_chunk();
-          if (!processor->try_handle(chunk)) {
+          if (!try_handle_chunk(chunk)) {
             LOG_VERBOSE << "not handled group " << i;
 
             if (processor->can_promote(chunk)) {
@@ -94,6 +94,10 @@ namespace dplyr {
             }
           }
         }
+      }
+
+      bool try_handle_chunk(const RObject& chunk) const {
+        return processor->try_handle(chunk);
       }
 
       RObject fetch_chunk() {

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -69,13 +69,9 @@ namespace dplyr {
 
       void process_first() {
         const RObject& first_result = fetch_chunk();
-
         LOG_VERBOSE << "instantiating delayed processor for type " << first_result.sexp_type();
 
         processor.reset(get_delayed_processor<CLASS>(first_result, ngroups));
-        if (!processor)
-          stop("expecting a single value");
-
         LOG_VERBOSE << "processing " << ngroups << " groups with " << processor->describe() << " processor";
       }
 

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -61,7 +61,7 @@ namespace dplyr {
 
       LOG_VERBOSE << "instantiating delayed processor for type " << first_result.sexp_type();
 
-      boost::scoped_ptr< DelayedProcessor_Base<CLASS> > processor(
+      boost::scoped_ptr<DelayedProcessor_Base> processor(
         get_delayed_processor<CLASS>(0, first_result, ngroups)
       );
       if (!processor)

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -80,14 +80,9 @@ namespace dplyr {
           if (!try_handle_chunk(chunk)) {
             LOG_VERBOSE << "not handled group " << i;
 
-            if (processor->can_promote(chunk)) {
-              processor.reset(
-                processor->promote(chunk)
-              );
+            processor.reset(processor->promote(chunk));
 
-              if (!processor)
-                stop("processor said it could promote but didn't");
-            } else {
+            if (!processor) {
               stop("can't promote group %d to %s", i, processor->describe());
             }
 

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -81,8 +81,6 @@ namespace dplyr {
             LOG_VERBOSE << "not handled group " << i;
 
             if (processor->can_promote(chunk)) {
-              LOG_VERBOSE << "promoting after group " << i;
-
               processor.reset(
                 processor->promote(chunk)
               );
@@ -92,6 +90,8 @@ namespace dplyr {
             } else {
               stop("can't promote group %d to %s", i, processor->describe());
             }
+
+            LOG_VERBOSE << "promoted group " << i;
           }
         }
       }

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -61,7 +61,7 @@ namespace dplyr {
 
       LOG_VERBOSE << "instantiating delayed processor for type " << first_result.sexp_type();
 
-      boost::scoped_ptr<DelayedProcessor_Base> processor(
+      boost::scoped_ptr<IDelayedProcessor> processor(
         get_delayed_processor<CLASS>(0, first_result, ngroups)
       );
       if (!processor)

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -88,6 +88,9 @@ namespace dplyr {
               processor.reset(
                 processor->promote(chunk)
               );
+
+              if (!processor)
+                stop("processor said it could promote but didn't");
             } else {
               stop("can't promote group %d to %s", i, processor->describe());
             }

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -67,7 +67,7 @@ namespace dplyr {
       if (!processor)
         stop("expecting a single value");
 
-      LOG_VERBOSE << "processing " << ngroups << " groups";
+      LOG_VERBOSE << "processing " << ngroups << " groups with " << processor->describe() << " processor";
 
       for (int i = 0; i < ngroups; ++i, ++git) {
         first_result = obj->process_chunk(*git);
@@ -81,7 +81,7 @@ namespace dplyr {
               processor->promote(i, first_result)
             );
           } else {
-            stop("can't promote group %d", i);
+            stop("can't promote group %d to %s", i, processor->describe());
           }
         }
       }

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -27,19 +27,20 @@ namespace dplyr {
   public:
     CallbackProcessor() {}
 
+    CLASS* obj() {
+      return static_cast<CLASS*>(this);
+    }
+
     virtual SEXP process(const GroupedDataFrame& gdf) {
-      CLASS* obj = static_cast<CLASS*>(this);
-      return process_data<GroupedDataFrame>(gdf, obj).run();
+      return process_data<GroupedDataFrame>(gdf, obj()).run();
     }
 
     virtual SEXP process(const RowwiseDataFrame& gdf) {
-      CLASS* obj = static_cast<CLASS*>(this);
-      return process_data<RowwiseDataFrame>(gdf, obj).run();
+      return process_data<RowwiseDataFrame>(gdf, obj()).run();
     }
 
     virtual SEXP process(const Rcpp::FullDataFrame& df) {
-      CLASS* obj = static_cast<CLASS*>(this);
-      return obj->process_chunk(df.get_index());
+      return obj()->process_chunk(df.get_index());
     }
 
     virtual SEXP process(const SlicingIndex& index) {

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -62,7 +62,7 @@ namespace dplyr {
       LOG_VERBOSE << "instantiating delayed processor for type " << first_result.sexp_type();
 
       boost::scoped_ptr<IDelayedProcessor> processor(
-        get_delayed_processor<CLASS>(0, first_result, ngroups)
+        get_delayed_processor<CLASS>(first_result, ngroups)
       );
       if (!processor)
         stop("expecting a single value");

--- a/inst/include/dplyr/Result/CallbackProcessor.h
+++ b/inst/include/dplyr/Result/CallbackProcessor.h
@@ -79,20 +79,23 @@ namespace dplyr {
           const RObject& chunk = fetch_chunk();
           if (!try_handle_chunk(chunk)) {
             LOG_VERBOSE << "not handled group " << i;
-
-            processor.reset(processor->promote(chunk));
-
-            if (!processor) {
-              stop("can't promote group %d to %s", i, processor->describe());
-            }
-
-            LOG_VERBOSE << "promoted group " << i;
+            handle_chunk_with_promotion(chunk, i);
           }
         }
       }
 
       bool try_handle_chunk(const RObject& chunk) const {
         return processor->try_handle(chunk);
+      }
+
+      void handle_chunk_with_promotion(const RObject& chunk, const int i) {
+        IDelayedProcessor* new_processor = processor->promote(chunk);
+        if (!new_processor) {
+          stop("can't promote group %d to %s", i, processor->describe());
+        }
+
+        LOG_VERBOSE << "promoted group " << i;
+        processor.reset(new_processor);
       }
 
       RObject fetch_chunk() {

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -4,6 +4,7 @@
 #include <tools/hash.h>
 #include <tools/ShrinkableVector.h>
 #include <tools/utils.h>
+#include <dplyr/vector_class.h>
 
 namespace dplyr {
 
@@ -16,6 +17,7 @@ namespace dplyr {
     virtual bool can_promote(const RObject& chunk) = 0;
     virtual IDelayedProcessor* promote(int i, const RObject& chunk) = 0;
     virtual SEXP get() = 0;
+    virtual std::string describe() = 0;
   };
 
   template <int RTYPE>
@@ -118,6 +120,10 @@ namespace dplyr {
       return res;
     }
 
+    virtual std::string describe() {
+      return vector_class<RTYPE>();
+    }
+
 
   private:
     Vec res;
@@ -147,6 +153,9 @@ namespace dplyr {
     }
     virtual SEXP get() {
       return res;
+    }
+    virtual std::string describe() {
+      return "character";
     }
 
   private:
@@ -199,6 +208,10 @@ namespace dplyr {
       return res;
     }
 
+    virtual std::string describe() {
+      return "factor";
+    }
+
   private:
 
     void update_levels(const CharacterVector& lev) {
@@ -243,6 +256,9 @@ namespace dplyr {
     }
     virtual SEXP get() {
       return res;
+    }
+    virtual std::string describe() {
+      return "list";
     }
 
   private:

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -14,7 +14,7 @@ namespace dplyr {
     IDelayedProcessor() {}
     virtual ~IDelayedProcessor() {}
 
-    virtual bool handled(int i, const RObject& chunk) = 0;
+    virtual bool try_handle(int i, const RObject& chunk) = 0;
     virtual bool can_promote(const RObject& chunk) = 0;
     virtual IDelayedProcessor* promote(int i, const RObject& chunk) = 0;
     virtual SEXP get() = 0;
@@ -86,7 +86,7 @@ namespace dplyr {
       res[i] = as<STORAGE>(chunk);
     }
 
-    virtual bool handled(int i, const RObject& chunk) {
+    virtual bool try_handle(int i, const RObject& chunk) {
       int rtype = TYPEOF(chunk);
       if (valid_conversion<RTYPE>(rtype)) {
         res[i] = as<STORAGE>(chunk);
@@ -145,10 +145,10 @@ namespace dplyr {
       CharacterVector levels = Rf_getAttrib(first_result, Rf_install("levels"));
       int n = levels.size();
       for (int i=0; i<n; i++) levels_map[ levels[i] ] = i+1;
-      handled(0, first_result);
+      try_handle(0, first_result);
     }
 
-    virtual bool handled(int i, const RObject& chunk) {
+    virtual bool try_handle(int i, const RObject& chunk) {
       CharacterVector lev = chunk.attr("levels");
       update_levels(lev);
 
@@ -211,7 +211,7 @@ namespace dplyr {
       copy_most_attributes(res, first_result);
     }
 
-    virtual bool handled(int i, const RObject& chunk) {
+    virtual bool try_handle(int i, const RObject& chunk) {
       if (is<List>(chunk) && Rf_length(chunk) == 1) {
         res[i] = maybe_copy(VECTOR_ELT(chunk, 0));
         return true;

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -3,6 +3,7 @@
 
 #include <tools/hash.h>
 #include <tools/ShrinkableVector.h>
+#include <tools/scalar_type.h>
 #include <tools/utils.h>
 #include <dplyr/vector_class.h>
 
@@ -68,7 +69,7 @@ namespace dplyr {
   template <int RTYPE, typename CLASS>
   class DelayedProcessor : public IDelayedProcessor {
   public:
-    typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
+    typedef typename traits::scalar_type<RTYPE>::type STORAGE;
     typedef Vector<RTYPE> Vec;
 
     DelayedProcessor(SEXP first_result, int ngroups_) :
@@ -128,37 +129,6 @@ namespace dplyr {
     Vec res;
 
 
-  };
-
-  template <typename CLASS>
-  class DelayedProcessor<STRSXP, CLASS> : public IDelayedProcessor {
-  public:
-    DelayedProcessor(SEXP first_result, int ngroups) :
-      res(ngroups)
-    {
-      res[0] = as<String>(first_result);
-      copy_most_attributes(res, first_result);
-    }
-
-    virtual bool handled(int i, const RObject& chunk) {
-      res[i] = as<String>(chunk);
-      return true;
-    }
-    virtual bool can_promote(const RObject& chunk) {
-      return false;
-    }
-    virtual IDelayedProcessor* promote(int i, const RObject& chunk) {
-      return 0;
-    }
-    virtual SEXP get() {
-      return res;
-    }
-    virtual std::string describe() {
-      return "character";
-    }
-
-  private:
-    CharacterVector res;
   };
 
   template <typename CLASS>

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -270,7 +270,7 @@ namespace dplyr {
   };
 
   template <typename CLASS>
-  IDelayedProcessor* get_delayed_processor(int i, SEXP first_result, int ngroups) {
+  IDelayedProcessor* get_delayed_processor(SEXP first_result, int ngroups) {
     if (Rf_inherits(first_result, "factor")) {
       return new FactorDelayedProcessor<CLASS>(first_result, ngroups);
     } else if (Rcpp::is<int>(first_result)) {

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -7,7 +7,6 @@
 
 namespace dplyr {
 
-  template <typename CLASS>
   class DelayedProcessor_Base {
   public:
     DelayedProcessor_Base() {}
@@ -65,7 +64,7 @@ namespace dplyr {
   }
 
   template <int RTYPE, typename CLASS>
-  class DelayedProcessor : public DelayedProcessor_Base<CLASS> {
+  class DelayedProcessor : public DelayedProcessor_Base {
   public:
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
     typedef Vector<RTYPE> Vec;
@@ -98,7 +97,7 @@ namespace dplyr {
     virtual bool can_promote(const RObject& chunk) {
       return valid_promotion<RTYPE>(TYPEOF(chunk));
     }
-    virtual DelayedProcessor_Base<CLASS>* promote(int i, const RObject& chunk) {
+    virtual DelayedProcessor_Base* promote(int i, const RObject& chunk) {
       int rtype = TYPEOF(chunk);
       switch (rtype) {
       case LGLSXP:
@@ -127,7 +126,7 @@ namespace dplyr {
   };
 
   template <typename CLASS>
-  class DelayedProcessor<STRSXP, CLASS> : public DelayedProcessor_Base<CLASS> {
+  class DelayedProcessor<STRSXP, CLASS> : public DelayedProcessor_Base {
   public:
     DelayedProcessor(int first_non_na_, SEXP first_result, int ngroups) :
       res(ngroups)
@@ -143,7 +142,7 @@ namespace dplyr {
     virtual bool can_promote(const RObject& chunk) {
       return false;
     }
-    virtual DelayedProcessor_Base<CLASS>* promote(int i, const RObject& chunk) {
+    virtual DelayedProcessor_Base* promote(int i, const RObject& chunk) {
       return 0;
     }
     virtual SEXP get() {
@@ -155,7 +154,7 @@ namespace dplyr {
   };
 
   template <typename CLASS>
-  class FactorDelayedProcessor : public DelayedProcessor_Base<CLASS> {
+  class FactorDelayedProcessor : public DelayedProcessor_Base {
   private:
     typedef dplyr_hash_map<SEXP,int> LevelsMap;
 
@@ -185,7 +184,7 @@ namespace dplyr {
     virtual bool can_promote(const RObject& chunk) {
       return false;
     }
-    virtual DelayedProcessor_Base<CLASS>* promote(int i, const RObject& chunk) {
+    virtual DelayedProcessor_Base* promote(int i, const RObject& chunk) {
       return 0;
     }
     virtual SEXP get() {
@@ -220,7 +219,7 @@ namespace dplyr {
 
 
   template <typename CLASS>
-  class DelayedProcessor<VECSXP, CLASS> : public DelayedProcessor_Base<CLASS> {
+  class DelayedProcessor<VECSXP, CLASS> : public DelayedProcessor_Base {
   public:
     DelayedProcessor(int first_non_na_, SEXP first_result, int ngroups) :
       res(ngroups)
@@ -239,7 +238,7 @@ namespace dplyr {
     virtual bool can_promote(const RObject& chunk) {
       return false;
     }
-    virtual DelayedProcessor_Base<CLASS>* promote(int i, const RObject& chunk) {
+    virtual DelayedProcessor_Base* promote(int i, const RObject& chunk) {
       return 0;
     }
     virtual SEXP get() {
@@ -255,7 +254,7 @@ namespace dplyr {
   };
 
   template <typename CLASS>
-  DelayedProcessor_Base<CLASS>* get_delayed_processor(int i, SEXP first_result, int ngroups) {
+  DelayedProcessor_Base* get_delayed_processor(int i, SEXP first_result, int ngroups) {
     if (Rf_inherits(first_result, "factor")) {
       return new FactorDelayedProcessor<CLASS>(i, first_result, ngroups);
     } else if (Rcpp::is<int>(first_result)) {

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -256,6 +256,9 @@ namespace dplyr {
 
   template <typename CLASS>
   IDelayedProcessor* get_delayed_processor(SEXP first_result, int ngroups) {
+    if (Rf_length(first_result) != 1)
+      stop("expecting a single value, got %d", Rf_length(first_result));
+
     if (Rf_inherits(first_result, "factor")) {
       return new FactorDelayedProcessor<CLASS>(first_result, ngroups);
     } else if (Rcpp::is<int>(first_result)) {
@@ -267,12 +270,12 @@ namespace dplyr {
     } else if (Rcpp::is<bool>(first_result)) {
       return new DelayedProcessor<LGLSXP, CLASS>(first_result, ngroups);
     } else if (Rcpp::is<Rcpp::List>(first_result)) {
-      if (Rf_length(first_result) != 1) return 0;
       return new DelayedProcessor<VECSXP, CLASS>(first_result, ngroups);
-    } else if (Rf_length(first_result) == 1 && TYPEOF(first_result) == CPLXSXP) {
+    } else if (TYPEOF(first_result) == CPLXSXP) {
       return new DelayedProcessor<CPLXSXP, CLASS>(first_result, ngroups);
     }
-    return 0;
+
+    stop("unknown result of type %d", TYPEOF(first_result));
   }
 
 }

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -14,9 +14,9 @@ namespace dplyr {
     IDelayedProcessor() {}
     virtual ~IDelayedProcessor() {}
 
-    virtual bool try_handle(int pos, const RObject& chunk) = 0;
+    virtual bool try_handle(const RObject& chunk) = 0;
     virtual bool can_promote(const RObject& chunk) = 0;
-    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) = 0;
+    virtual IDelayedProcessor* promote(const RObject& chunk) = 0;
     virtual SEXP get() = 0;
     virtual std::string describe() = 0;
   };
@@ -72,24 +72,26 @@ namespace dplyr {
     typedef typename traits::scalar_type<RTYPE>::type STORAGE;
     typedef Vector<RTYPE> Vec;
 
-    DelayedProcessor(SEXP first_result, int ngroups_) :
-      res(no_init(ngroups_))
+    DelayedProcessor(const RObject& first_result, int ngroups_) :
+      res(no_init(ngroups_)), pos(0)
     {
-      res[0] = as<STORAGE>(first_result);
+      if (!try_handle(first_result))
+        stop("cannot handle result of type %i", first_result.sexp_type());
       copy_column_attributes(res, first_result);
     }
 
-    DelayedProcessor(int pos, const RObject& chunk, SEXP res_) :
-      res(as<Vec>(res_))
+    DelayedProcessor(int pos_, const RObject& chunk, SEXP res_) :
+      res(as<Vec>(res_)), pos(pos_)
     {
       copy_most_attributes(res, chunk);
-      res[pos] = as<STORAGE>(chunk);
+      if (!try_handle(chunk))
+        stop("cannot handle result of type %i in promotion", chunk.sexp_type());
     }
 
-    virtual bool try_handle(int pos, const RObject& chunk) {
+    virtual bool try_handle(const RObject& chunk) {
       int rtype = TYPEOF(chunk);
       if (valid_conversion<RTYPE>(rtype)) {
-        res[pos] = as<STORAGE>(chunk);
+        res[pos++] = as<STORAGE>(chunk);
         return true;
       } else {
         return false;
@@ -100,7 +102,7 @@ namespace dplyr {
       return valid_promotion<RTYPE>(TYPEOF(chunk));
     }
 
-    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) {
+    virtual IDelayedProcessor* promote(const RObject& chunk) {
       int rtype = TYPEOF(chunk);
       switch (rtype) {
       case LGLSXP:
@@ -128,6 +130,7 @@ namespace dplyr {
 
   private:
     Vec res;
+    int pos;
 
 
   };
@@ -140,16 +143,17 @@ namespace dplyr {
   public:
 
     FactorDelayedProcessor(SEXP first_result, int ngroups) :
-      res(ngroups, NA_INTEGER)
+      res(ngroups, NA_INTEGER), pos(0)
     {
       copy_most_attributes(res, first_result);
       CharacterVector levels = Rf_getAttrib(first_result, Rf_install("levels"));
       int n = levels.size();
       for (int i=0; i<n; i++) levels_map[ levels[i] ] = i+1;
-      try_handle(0, first_result);
+      if (!try_handle(first_result))
+        stop("cannot handle factor result");
     }
 
-    virtual bool try_handle(int pos, const RObject& chunk) {
+    virtual bool try_handle(const RObject& chunk) {
       CharacterVector lev = chunk.attr("levels");
       update_levels(lev);
 
@@ -158,7 +162,7 @@ namespace dplyr {
         return true;
       }
       SEXP s = lev[val-1];
-      res[pos] = levels_map[s];
+      res[pos++] = levels_map[s];
       return true;
     }
 
@@ -166,7 +170,7 @@ namespace dplyr {
       return false;
     }
 
-    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) {
+    virtual IDelayedProcessor* promote(const RObject& chunk) {
       return 0;
     }
 
@@ -200,6 +204,7 @@ namespace dplyr {
     }
 
     IntegerVector res;
+    int pos;
     LevelsMap levels_map;
   };
 
@@ -209,15 +214,16 @@ namespace dplyr {
   class DelayedProcessor<VECSXP, CLASS> : public IDelayedProcessor {
   public:
     DelayedProcessor(SEXP first_result, int ngroups) :
-      res(ngroups)
+      res(ngroups), pos(0)
     {
-      res[0] = maybe_copy(VECTOR_ELT(first_result, 0));
       copy_most_attributes(res, first_result);
+      if (!try_handle(first_result))
+        stop("cannot handle list result");
     }
 
-    virtual bool try_handle(int pos, const RObject& chunk) {
+    virtual bool try_handle(const RObject& chunk) {
       if (is<List>(chunk) && Rf_length(chunk) == 1) {
-        res[pos] = maybe_copy(VECTOR_ELT(chunk, 0));
+        res[pos++] = maybe_copy(VECTOR_ELT(chunk, 0));
         return true;
       }
       return false;
@@ -227,7 +233,7 @@ namespace dplyr {
       return false;
     }
 
-    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) {
+    virtual IDelayedProcessor* promote(const RObject& chunk) {
       return 0;
     }
 
@@ -241,6 +247,7 @@ namespace dplyr {
 
   private:
     List res;
+    int pos;
 
     inline SEXP maybe_copy(SEXP x) const {
       return is_ShrinkableVector(x) ? Rf_duplicate(x) : x;

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -71,11 +71,10 @@ namespace dplyr {
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
     typedef Vector<RTYPE> Vec;
 
-    DelayedProcessor(int first_non_na, SEXP first_result, int ngroups_) :
+    DelayedProcessor(SEXP first_result, int ngroups_) :
       res(no_init(ngroups_))
     {
-      std::fill(res.begin(), res.begin() + first_non_na, Vec::get_na());
-      res[first_non_na] = as<STORAGE>(first_result);
+      res[0] = as<STORAGE>(first_result);
       copy_column_attributes(res, first_result);
     }
 
@@ -134,10 +133,10 @@ namespace dplyr {
   template <typename CLASS>
   class DelayedProcessor<STRSXP, CLASS> : public IDelayedProcessor {
   public:
-    DelayedProcessor(int first_non_na_, SEXP first_result, int ngroups) :
+    DelayedProcessor(SEXP first_result, int ngroups) :
       res(ngroups)
     {
-      res[first_non_na_] = as<String>(first_result);
+      res[0] = as<String>(first_result);
       copy_most_attributes(res, first_result);
     }
 
@@ -169,13 +168,14 @@ namespace dplyr {
 
   public:
 
-    FactorDelayedProcessor(int first_non_na, SEXP first_result, int ngroups) :
+    FactorDelayedProcessor(SEXP first_result, int ngroups) :
       res(ngroups, NA_INTEGER)
     {
       copy_most_attributes(res, first_result);
       CharacterVector levels = Rf_getAttrib(first_result, Rf_install("levels"));
       int n = levels.size();
       for (int i=0; i<n; i++) levels_map[ levels[i] ] = i+1;
+      handled(0, first_result);
     }
 
     virtual bool handled(int i, const RObject& chunk) {
@@ -234,10 +234,10 @@ namespace dplyr {
   template <typename CLASS>
   class DelayedProcessor<VECSXP, CLASS> : public IDelayedProcessor {
   public:
-    DelayedProcessor(int first_non_na_, SEXP first_result, int ngroups) :
+    DelayedProcessor(SEXP first_result, int ngroups) :
       res(ngroups)
     {
-      res[first_non_na_] = maybe_copy(VECTOR_ELT(first_result, 0));
+      res[0] = maybe_copy(VECTOR_ELT(first_result, 0));
       copy_most_attributes(res, first_result);
     }
 
@@ -272,20 +272,20 @@ namespace dplyr {
   template <typename CLASS>
   IDelayedProcessor* get_delayed_processor(int i, SEXP first_result, int ngroups) {
     if (Rf_inherits(first_result, "factor")) {
-      return new FactorDelayedProcessor<CLASS>(i, first_result, ngroups);
+      return new FactorDelayedProcessor<CLASS>(first_result, ngroups);
     } else if (Rcpp::is<int>(first_result)) {
-      return new DelayedProcessor<INTSXP, CLASS>(i, first_result, ngroups);
+      return new DelayedProcessor<INTSXP, CLASS>(first_result, ngroups);
     } else if (Rcpp::is<double>(first_result)) {
-      return new DelayedProcessor<REALSXP, CLASS>(i, first_result, ngroups);
+      return new DelayedProcessor<REALSXP, CLASS>(first_result, ngroups);
     } else if (Rcpp::is<Rcpp::String>(first_result)) {
-      return new DelayedProcessor<STRSXP, CLASS>(i, first_result, ngroups);
+      return new DelayedProcessor<STRSXP, CLASS>(first_result, ngroups);
     } else if (Rcpp::is<bool>(first_result)) {
-      return new DelayedProcessor<LGLSXP, CLASS>(i, first_result, ngroups);
+      return new DelayedProcessor<LGLSXP, CLASS>(first_result, ngroups);
     } else if (Rcpp::is<Rcpp::List>(first_result)) {
       if (Rf_length(first_result) != 1) return 0;
-      return new DelayedProcessor<VECSXP, CLASS>(i, first_result, ngroups);
+      return new DelayedProcessor<VECSXP, CLASS>(first_result, ngroups);
     } else if (Rf_length(first_result) == 1 && TYPEOF(first_result) == CPLXSXP) {
-      return new DelayedProcessor<CPLXSXP, CLASS>(i, first_result, ngroups);
+      return new DelayedProcessor<CPLXSXP, CLASS>(first_result, ngroups);
     }
     return 0;
   }

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -14,9 +14,9 @@ namespace dplyr {
     IDelayedProcessor() {}
     virtual ~IDelayedProcessor() {}
 
-    virtual bool try_handle(int i, const RObject& chunk) = 0;
+    virtual bool try_handle(int pos, const RObject& chunk) = 0;
     virtual bool can_promote(const RObject& chunk) = 0;
-    virtual IDelayedProcessor* promote(int i, const RObject& chunk) = 0;
+    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) = 0;
     virtual SEXP get() = 0;
     virtual std::string describe() = 0;
   };
@@ -79,17 +79,17 @@ namespace dplyr {
       copy_column_attributes(res, first_result);
     }
 
-    DelayedProcessor(int i, const RObject& chunk, SEXP res_) :
+    DelayedProcessor(int pos, const RObject& chunk, SEXP res_) :
       res(as<Vec>(res_))
     {
       copy_most_attributes(res, chunk);
-      res[i] = as<STORAGE>(chunk);
+      res[pos] = as<STORAGE>(chunk);
     }
 
-    virtual bool try_handle(int i, const RObject& chunk) {
+    virtual bool try_handle(int pos, const RObject& chunk) {
       int rtype = TYPEOF(chunk);
       if (valid_conversion<RTYPE>(rtype)) {
-        res[i] = as<STORAGE>(chunk);
+        res[pos] = as<STORAGE>(chunk);
         return true;
       } else {
         return false;
@@ -99,17 +99,18 @@ namespace dplyr {
     virtual bool can_promote(const RObject& chunk) {
       return valid_promotion<RTYPE>(TYPEOF(chunk));
     }
-    virtual IDelayedProcessor* promote(int i, const RObject& chunk) {
+
+    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) {
       int rtype = TYPEOF(chunk);
       switch (rtype) {
       case LGLSXP:
-        return new DelayedProcessor<LGLSXP , CLASS>(i, chunk, res);
+        return new DelayedProcessor<LGLSXP , CLASS>(pos, chunk, res);
       case INTSXP:
-        return new DelayedProcessor<INTSXP , CLASS>(i, chunk, res);
+        return new DelayedProcessor<INTSXP , CLASS>(pos, chunk, res);
       case REALSXP:
-        return new DelayedProcessor<REALSXP, CLASS>(i, chunk, res);
+        return new DelayedProcessor<REALSXP, CLASS>(pos, chunk, res);
       case CPLXSXP:
-        return new DelayedProcessor<CPLXSXP, CLASS>(i, chunk, res);
+        return new DelayedProcessor<CPLXSXP, CLASS>(pos, chunk, res);
       default:
         break;
       }
@@ -148,7 +149,7 @@ namespace dplyr {
       try_handle(0, first_result);
     }
 
-    virtual bool try_handle(int i, const RObject& chunk) {
+    virtual bool try_handle(int pos, const RObject& chunk) {
       CharacterVector lev = chunk.attr("levels");
       update_levels(lev);
 
@@ -157,15 +158,18 @@ namespace dplyr {
         return true;
       }
       SEXP s = lev[val-1];
-      res[i] = levels_map[s];
+      res[pos] = levels_map[s];
       return true;
     }
+
     virtual bool can_promote(const RObject& chunk) {
       return false;
     }
-    virtual IDelayedProcessor* promote(int i, const RObject& chunk) {
+
+    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) {
       return 0;
     }
+
     virtual SEXP get() {
       int n = levels_map.size();
       CharacterVector levels(n);
@@ -211,22 +215,26 @@ namespace dplyr {
       copy_most_attributes(res, first_result);
     }
 
-    virtual bool try_handle(int i, const RObject& chunk) {
+    virtual bool try_handle(int pos, const RObject& chunk) {
       if (is<List>(chunk) && Rf_length(chunk) == 1) {
-        res[i] = maybe_copy(VECTOR_ELT(chunk, 0));
+        res[pos] = maybe_copy(VECTOR_ELT(chunk, 0));
         return true;
       }
       return false;
     }
+
     virtual bool can_promote(const RObject& chunk) {
       return false;
     }
-    virtual IDelayedProcessor* promote(int i, const RObject& chunk) {
+
+    virtual IDelayedProcessor* promote(int pos, const RObject& chunk) {
       return 0;
     }
+
     virtual SEXP get() {
       return res;
     }
+
     virtual std::string describe() {
       return "list";
     }

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -44,10 +44,14 @@ namespace dplyr {
 
       if (TYPEOF(call) == LANGSXP) {
         if (can_simplify(call)) {
+          LOG_VERBOSE << "performing hybrid evaluation";
           HybridCall hybrid_eval(call, indices, subsets, env);
           return hybrid_eval.eval();
         }
+
         int n = proxies.size();
+
+        LOG_VERBOSE << "setting " << n << " proxies";
         for (int i=0; i<n; i++) {
           proxies[i].set(subsets.get(proxies[i].symbol, indices));
         }

--- a/inst/include/dplyr/Result/Lag.h
+++ b/inst/include/dplyr/Result/Lag.h
@@ -11,7 +11,7 @@ namespace dplyr {
   template <int RTYPE>
   class Lag : public Result {
   public:
-    typedef typename scalar_type<RTYPE>::type STORAGE;
+    typedef typename traits::scalar_type<RTYPE>::type STORAGE;
 
     Lag(SEXP data_, int n_, const RObject& def_, bool is_summary_) :
       data(data_),

--- a/inst/include/dplyr/Result/Lag.h
+++ b/inst/include/dplyr/Result/Lag.h
@@ -1,6 +1,7 @@
 #ifndef dplyr_Result_Lag_H
 #define dplyr_Result_Lag_H
 
+#include <tools/scalar_type.h>
 #include <tools/utils.h>
 
 #include <dplyr/Result/Result.h>

--- a/inst/include/dplyr/Result/Lead.h
+++ b/inst/include/dplyr/Result/Lead.h
@@ -1,20 +1,12 @@
 #ifndef dplyr_Result_Lead_H
 #define dplyr_Result_Lead_H
 
+#include <tools/scalar_type.h>
 #include <tools/utils.h>
 
 #include <dplyr/Result/Result.h>
 
 namespace dplyr {
-
-  template <int RTYPE>
-  struct scalar_type {
-    typedef typename traits::storage_type<RTYPE>::type type;
-  };
-  template <>
-  struct scalar_type<STRSXP> {
-    typedef String type;
-  };
 
   template <int RTYPE>
   class Lead : public Result {

--- a/inst/include/dplyr/Result/Lead.h
+++ b/inst/include/dplyr/Result/Lead.h
@@ -11,7 +11,7 @@ namespace dplyr {
   template <int RTYPE>
   class Lead : public Result {
   public:
-    typedef typename scalar_type<RTYPE>::type STORAGE;
+    typedef typename traits::scalar_type<RTYPE>::type STORAGE;
 
     Lead(SEXP data_, int n_, const RObject& def_, bool is_summary_) :
       data(data_),

--- a/inst/include/tools/ShrinkableVector.h
+++ b/inst/include/tools/ShrinkableVector.h
@@ -9,7 +9,7 @@ namespace Rcpp {
   template <int RTYPE>
   class ShrinkableVector {
   public:
-    typedef typename traits::storage_type<RTYPE>::type STORAGE;
+    typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
     ShrinkableVector(int n, SEXP origin) :
       data(no_init(n)), max_size(n), start(internal::r_vector_start<RTYPE>(data)), gp(LEVELS(data))

--- a/inst/include/tools/scalar_type.h
+++ b/inst/include/tools/scalar_type.h
@@ -1,13 +1,22 @@
 #ifndef DPLYR_SCALAR_TYPE_H
 #define DPLYR_SCALAR_TYPE_H
 
-template <int RTYPE>
-struct scalar_type {
-  typedef typename traits::storage_type<RTYPE>::type type;
-};
-template <>
-struct scalar_type<STRSXP> {
-  typedef String type;
-};
+namespace dplyr {
+
+  namespace traits {
+
+    template <int RTYPE>
+    struct scalar_type {
+      typedef typename Rcpp::traits::storage_type<RTYPE>::type type;
+    };
+
+    template <>
+    struct scalar_type<STRSXP> {
+      typedef String type;
+    };
+
+  }
+
+}
 
 #endif //DPLYR_SCALAR_TYPE_H

--- a/inst/include/tools/scalar_type.h
+++ b/inst/include/tools/scalar_type.h
@@ -1,0 +1,13 @@
+#ifndef DPLYR_SCALAR_TYPE_H
+#define DPLYR_SCALAR_TYPE_H
+
+template <int RTYPE>
+struct scalar_type {
+  typedef typename traits::storage_type<RTYPE>::type type;
+};
+template <>
+struct scalar_type<STRSXP> {
+  typedef String type;
+};
+
+#endif //DPLYR_SCALAR_TYPE_H

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -26,8 +26,10 @@ SEXP summarise_grouped(const DataFrame& df, const LazyDots& dots) {
   int nexpr = dots.size();
   int nvars = gdf.nvars();
   check_not_groups(dots, gdf);
-  NamedListAccumulator<Data> accumulator;
 
+  LOG_VERBOSE << "copying data to accumulator";
+
+  NamedListAccumulator<Data> accumulator;
   int i=0;
   List results(nvars + nexpr);
   for (; i<nvars; i++) {
@@ -35,11 +37,15 @@ SEXP summarise_grouped(const DataFrame& df, const LazyDots& dots) {
     accumulator.set(PRINTNAME(gdf.symbol(i)), results[i]);
   }
 
+  LOG_VERBOSE <<  "processing " << nexpr << " variables";
+
   Subsets subsets(gdf);
   for (int k=0; k<nexpr; k++, i++) {
     Rcpp::checkUserInterrupt();
     const Lazy& lazy = dots[k];
     const Environment& env = lazy.env();
+
+    LOG_VERBOSE << "processing variable " << CHAR(lazy.name());
 
     Shield<SEXP> expr_(lazy.expr());
     SEXP expr = expr_;

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -673,18 +673,29 @@ test_that("typing and NAs for grouped summarise (#1839)", {
       summarise(a = a[[1]]) %>%
       .$a,
     NA_character_)
+
   expect_identical(
     data_frame(id = 1:2, a = c(NA, "a")) %>%
       group_by(id) %>%
       summarise(a = a[[1]]) %>%
       .$a,
     c(NA, "a"))
+
+  # Properly upgrade NA (logical) to character
+  expect_identical(
+    data_frame(id = 1:2, a = 1:2) %>%
+      group_by(id) %>%
+      summarise(a = ifelse(all(a < 2), NA, "yes")) %>%
+      .$a,
+    c(NA, "yes"))
+
   expect_error(
     data_frame(id = 1:2, a = list(1, "2")) %>%
       group_by(id) %>%
       summarise(a = a[[1]]) %>%
       .$a,
     "can't promote")
+
   expect_identical(
     data_frame(id = 1:2, a = list(1, "2")) %>%
       group_by(id) %>%
@@ -700,12 +711,22 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
       summarise(a = a[[1]]) %>%
       .$a,
     NA_character_)
+
   expect_identical(
     data_frame(id = 1:2, a = c(NA, "a")) %>%
       rowwise %>%
       summarise(a = a[[1]]) %>%
       .$a,
     c(NA, "a"))
+
+  # Properly promote NA (logical) to character
+  expect_identical(
+    data_frame(id = 1:2, a = 1:2) %>%
+      group_by(id) %>%
+      summarise(a = ifelse(all(a < 2), NA, "yes")) %>%
+      .$a,
+    c(NA, "yes"))
+
   expect_error(
     data_frame(id = 1:2, a = list(1, "2")) %>%
       rowwise %>%

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -665,3 +665,59 @@ test_that("dim attribute is stripped from grouped summarise (#1918)", {
   expect_null(dim(df_grouped$b))
   expect_null(dim(df_rowwise$b))
 })
+
+test_that("typing and NAs for grouped summarise (#1839)", {
+  expect_identical(
+    data_frame(id = 1L, a = NA_character_) %>%
+      group_by(id) %>%
+      summarise(a = a[[1]]) %>%
+      .$a,
+    NA_character_)
+  expect_identical(
+    data_frame(id = 1:2, a = c(NA, "a")) %>%
+      group_by(id) %>%
+      summarise(a = a[[1]]) %>%
+      .$a,
+    c(NA, "a"))
+  expect_error(
+    data_frame(id = 1:2, a = list(1, "2")) %>%
+      group_by(id) %>%
+      summarise(a = a[[1]]) %>%
+      .$a,
+    "can't promote")
+  expect_identical(
+    data_frame(id = 1:2, a = list(1, "2")) %>%
+      group_by(id) %>%
+      summarise(a = a[1]) %>%
+      .$a,
+    list(1, "2"))
+})
+
+test_that("typing and NAs for rowwise summarise (#1839)", {
+  expect_identical(
+    data_frame(id = 1L, a = NA_character_) %>%
+      rowwise %>%
+      summarise(a = a[[1]]) %>%
+      .$a,
+    NA_character_)
+  expect_identical(
+    data_frame(id = 1:2, a = c(NA, "a")) %>%
+      rowwise %>%
+      summarise(a = a[[1]]) %>%
+      .$a,
+    c(NA, "a"))
+  expect_error(
+    data_frame(id = 1:2, a = list(1, "2")) %>%
+      rowwise %>%
+      summarise(a = a[[1]]) %>%
+      .$a,
+    "can't promote")
+
+  skip("#2145")
+  expect_identical(
+    data_frame(id = 1:2, a = list(1, "2")) %>%
+      rowwise %>%
+      summarise(a = a[1]) %>%
+      .$a,
+    list(1, "2"))
+})


### PR DESCRIPTION
- CallbackProcessor follows clean code standards
- DelayedProcessor tracks its position and allows conversion to any type as long as only NAs were seen
- get_delayed_processor() now is responsible for delivering a clean error message
- Remove unneeded specialization of DelayedProcessor 

hadley#1839
