### PR TITLE
Better default values for size of some hash tables

### DIFF
--- a/inst/include/dplyr/Result/Count_Distinct.h
+++ b/inst/include/dplyr/Result/Count_Distinct.h
@@ -17,11 +17,12 @@ namespace dplyr {
     typedef dplyr_hash_set<int, Hash, Pred > Set;
 
     Count_Distinct(Visitor v_):
-      v(v_), set(1024, Hash(v), Pred(v))
+      v(v_), set(0, Hash(v), Pred(v))
     {}
 
     inline int process_chunk(const SlicingIndex& indices) {
       set.clear();
+      set.rehash(indices.size());
       int n = indices.size();
       for (int i=0; i<n; i++) {
         set.insert(indices[i]);
@@ -42,11 +43,12 @@ namespace dplyr {
     typedef dplyr_hash_set<int, Hash, Pred > Set;
 
     Count_Distinct_Narm(Visitor v_):
-      v(v_), set(1024, Hash(v), Pred(v))
+      v(v_), set(0, Hash(v), Pred(v))
     {}
 
     inline int process_chunk(const SlicingIndex& indices) {
       set.clear();
+      set.rehash(indices.size());
       int n = indices.size();
       for (int i=0; i<n; i++) {
         int index=indices[i];

--- a/inst/include/dplyr/Result/In.h
+++ b/inst/include/dplyr/Result/In.h
@@ -13,10 +13,9 @@ namespace dplyr {
     typedef typename Rcpp::Vector<RTYPE> Vec;
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
-    In(Vec data_, Vec table_) :
+    In(Vec data_, const Vec& table_) :
       data(data_),
-      table(table_),
-      set(table.begin(), table.end())
+      set(table_.begin(), table_.end())
     {}
 
     void process_slice(LogicalVector& out, const SlicingIndex& index, const SlicingIndex& out_index) {
@@ -32,7 +31,7 @@ namespace dplyr {
     }
 
   private:
-    Vec data, table;
+    Vec data;
     dplyr_hash_set<STORAGE> set;
 
   };

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -293,7 +293,7 @@ namespace dplyr {
 
   CharacterVectorOrderer::CharacterVectorOrderer(const CharacterVector& data_) :
     data(data_),
-    set(),
+    set(data.size()),
     orders(no_init(data.size()))
   {
     int n = data.size();


### PR DESCRIPTION
to avoid rehashing and speed up e.g. n_distinct()

hadley#977
